### PR TITLE
Dockerfile: install python3

### DIFF
--- a/Dockerfile.imagebuilder
+++ b/Dockerfile.imagebuilder
@@ -1,9 +1,24 @@
 FROM debian:latest
 
+MAINTAINER Paul Spooren <mail@aparcar.org>
+
 RUN apt-get update -qq &&\
-    apt-get install -y build-essential libncurses5-dev gawk git subversion \
-        libssl-dev gettext zlib1g-dev swig unzip python2.7 wget file &&\
-        apt-get -y autoremove && apt-get clean
+    apt-get install -y \
+        build-essential \
+        file \
+        gawk \
+        gettext \
+        git \
+        libncurses5-dev \
+        libssl-dev \
+        python2.7 \
+        python3 \
+        subversion \
+        swig \
+        unzip \
+        wget \
+        zlib1g-dev \
+        && apt-get -y autoremove && apt-get clean
 
 RUN useradd -c "OpenWrt Builder" -m -d /home/build -s /bin/bash build
 COPY --chown=build:build ./imagebuilder /home/build/imagebuilder

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -1,9 +1,24 @@
 FROM debian:latest
 
+MAINTAINER Paul Spooren <mail@aparcar.org>
+
 RUN apt-get update -qq &&\
-    apt-get install -y build-essential libncurses5-dev gawk git subversion \
-        libssl-dev gettext zlib1g-dev swig unzip python2.7 wget file &&\
-        apt-get -y autoremove && apt-get clean
+    apt-get install -y \
+        build-essential \
+        file \
+        gawk \
+        gettext \
+        git \
+        libncurses5-dev \
+        libssl-dev \
+        python2.7 \
+        python3 \
+        subversion \
+        swig \
+        unzip \
+        wget \
+        zlib1g-dev \
+        && apt-get -y autoremove && apt-get clean
 
 RUN useradd -c "OpenWrt Builder" -m -d /home/build -s /bin/bash build
 COPY --chown=build:build ./sdk /home/build/sdk


### PR DESCRIPTION
Python3 is now a requirement for the buildroot and must therefore exist
in the sdk/imagebuilder containers.

Also sorted the package list and added myself as maintainer.

Signed-off-by: Paul Spooren <mail@aparcar.org>