### PR TITLE
fixup: install signify-openbsd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,10 @@ jobs:
           command: bash docker-sdk.sh
 
   rootfs-snapshot:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
+      - run: sudo apt update && sudo apt install signify-openbsd
       - checkout
       - run: bash docker-common.sh
       - run:
@@ -30,8 +32,10 @@ jobs:
             TARGETS: "x86-64 armvirt-32 armvirt-64"
 
   imagebuilder-snapshot:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
+      - run: sudo apt update && sudo apt install signify-openbsd
       - checkout
       - run: bash docker-common.sh
       - run:
@@ -42,8 +46,10 @@ jobs:
             TARGETS: "cns3xxx-generic mvebu-cortexa53 mvebu-cortexa72 mvebu-cortexa9 ipq40xx-generic ipq806x-generic layerscape-armv7 layerscape-armv8_32b layerscape-armv8_64b imx6-generic octeontx-generic sunxi-cortexa8 sunxi-cortexa53 sunxi-cortexa7 ppc44x-generic bcm53xx-generic brcm47xx-mips74k brcm47xx-generic brcm47xx-legacy ath79-nand ath79-generic ath79-tiny ath25-generic mcs814x-generic ar7-ac49x ar7-generic kirkwood-generic apm821xx-sata apm821xx-nand ramips-rt305x ramips-rt3883 ramips-mt76x8 ramips-mt7620 ramips-rt288x ramips-mt7621 au1000-au1550 au1000-au1500 pistachio-generic gemini-wiligear gemini-generic gemini-raidsonic brcm2708-bcm2708 brcm2708-bcm2709 brcm2708-bcm2710 x86-geode x86-generic x86-legacy x86-64 lantiq-xway_legacy lantiq-xrx200 lantiq-ase lantiq-falcon lantiq-xway mediatek-mt7622 mediatek-mt7623 mediatek-32 mpc85xx-p1020 mpc85xx-p2020 mpc85xx-generic tegra-generic zynq-generic archs38-generic ixp4xx-harddisk ixp4xx-generic mxs-generic oxnas-ox820 octeon-generic armvirt-32 armvirt-64 arc770-generic adm8668-generic xburst-qi_lb60 samsung-s5pv210 omap-generic ar71xx-nand ar71xx-generic ar71xx-tiny ar71xx-mikrotik brcm63xx-generic brcm63xx-smp at91-sama5d3 at91-sama5d4 at91-sam9x at91-sama5 at91-legacy at91-sama5d2 rb532-generic malta-le malta-be malta-be64 malta-le64"
 
   sdk-snapshot:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
+      - run: sudo apt update && sudo apt install signify-openbsd
       - checkout
       - run: bash docker-common.sh
       - run:


### PR DESCRIPTION
While the pull requests already did so, the regular containers lacked
the signify-openbsd tool.

Signed-off-by: Paul Spooren <mail@aparcar.org>