### PR TITLE
fixup: rootfs uses a different Dockerfile

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,17 +2,19 @@
 
 set -ex
 
+DOCKERFILE="${DOCKERFILE:-Dockerfile}"
+
 if [ "$BRANCH" != "master" ]; then
     if [ "$TARGET" != "x86-64" ]; then
-        docker build -t "$DOCKER_IMAGE:$TARGET-$BRANCH" -f Dockerfile ./build
+        docker build -t "$DOCKER_IMAGE:$TARGET-$BRANCH" -f "$DOCKERFILE" ./build
     else
-        docker build -t "$DOCKER_IMAGE:$BRANCH" -f Dockerfile ./build
+        docker build -t "$DOCKER_IMAGE:$BRANCH" -f "$DOCKERFILE" ./build
     fi
 else
     if [ "$TARGET" != "x86-64" ]; then
-        docker build -t "$DOCKER_IMAGE:$TARGET" -f Dockerfile ./build
+        docker build -t "$DOCKER_IMAGE:$TARGET" -f "$DOCKERFILE" ./build
     else
-        docker build -t "$DOCKER_IMAGE:latest" -f Dockerfile ./build
+        docker build -t "$DOCKER_IMAGE:latest" -f "$DOCKERFILE" ./build
     fi
 fi
 

--- a/docker-rootfs.sh
+++ b/docker-rootfs.sh
@@ -6,6 +6,7 @@ TARGETS="${TARGETS:-x86-64}"
 BRANCHES="${BRANCHES:-master}"
 export DOCKER_IMAGE="${DOCKER_IMAGE:-openwrt-rootfs}"
 export DOWNLOAD_FILE="openwrt-*-rootfs.tar.gz"
+export DOCKERFILE="Dockerfile.rootfs"
 
 for TARGET in $TARGETS ; do
     export TARGET


### PR DESCRIPTION
ImagBuilder and SDK use a different Dockerfile than the rootfs, this was
missed while refactoring for GitLab.

Signed-off-by: Paul Spooren <mail@aparcar.org>