### PR TITLE
fixup: support other branches for rootfs

### DIFF
--- a/docker-rootfs.sh
+++ b/docker-rootfs.sh
@@ -12,7 +12,11 @@ for TARGET in $TARGETS ; do
     export TARGET
     for BRANCH in $BRANCHES; do
         export BRANCH
-        export DOWNLOAD_PATH="snapshots/targets/$(echo $TARGET | tr '-' '/')"
+        if [ "$BRANCH" == "master" ]; then
+            export DOWNLOAD_PATH="snapshots/targets/$(echo $TARGET | tr '-' '/')"
+        else
+            export DOWNLOAD_PATH="releases/$BRANCH/targets/$(echo $TARGET | tr '-' '/')"
+        fi
 
         ./docker-download.sh || exit 1
 


### PR DESCRIPTION
Initially the rootfs would only support snapshot builds as the stable
18.06.x wouldn't support Docker due to procd limitations. This was fixed
and therefore 19.07.x should also be supported.

Signed-off-by: Paul Spooren <mail@aparcar.org>