### PR TITLE
docker-common: remove login as it's done by CI

### DIFF
--- a/docker-common.sh
+++ b/docker-common.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-set -e
-
-[ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ] && docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+set -ex
 
 # LEDE Build System (LEDE GnuPG key for unattended build jobs)
 curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/626471F1.asc' | gpg --import \


### PR DESCRIPTION
This makes more sense as local users wouldn't use this function anyway.

Signed-off-by: Paul Spooren <mail@aparcar.org>