### PR TITLE
use GNUHOME to use ./gpg

### DIFF
--- a/docker-common.sh
+++ b/docker-common.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+mkdir -p "gpg"
+chmod 700 "gpg"
+export GNUPGHOME="gpg"
+
 # LEDE Build System (LEDE GnuPG key for unattended build jobs)
 curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/626471F1.asc' | gpg --import \
     && echo '54CC74307A2C6DC9CE618269CD84BCED626471F1:6:' | gpg --import-ownertrust

--- a/docker-download.sh
+++ b/docker-download.sh
@@ -3,6 +3,7 @@
 set -ex
 
 export FILE_HOST="${FILE_HOST:-downloads.openwrt.org}"
+export GNUPGHOME="gpg"
 
 curl "https://$FILE_HOST/$DOWNLOAD_PATH/sha256sums" -fs -o sha256sums
 curl "https://$FILE_HOST/$DOWNLOAD_PATH/sha256sums.asc" -fs -o sha256sums.asc || true


### PR DESCRIPTION
This prevents mixing of keys when running the scripts locally for
testing, the same is done for the using keys.

Signed-off-by: Paul Spooren <mail@aparcar.org>