### PR TITLE
replace true with exit when download fails

### DIFF
--- a/docker-rootfs.sh
+++ b/docker-rootfs.sh
@@ -15,7 +15,7 @@ else
 fi
 export DOWNLOAD_PATH
 
-./docker-download.sh || true
+./docker-download.sh || exit 1
 
 cp -r ./rootfs/* ./build
 

--- a/docker-sdk.sh
+++ b/docker-sdk.sh
@@ -14,5 +14,5 @@ else
 fi
 export DOWNLOAD_PATH
 
-./docker-download.sh || true
+./docker-download.sh || exit 1
 ./docker-build.sh || exit 1


### PR DESCRIPTION
previously multiple targets were combined in a single job so failing
targets should not stop others from being deployed. However as there are
now single builds per target this is no longer required.

Signed-off-by: Paul Spooren <mail@aparcar.org>