### PR TITLE
set pre-build as first stage again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,8 +11,8 @@ include:
   - remote: https://gitlab.com/ynezz/openwrt-ci/raw/master/openwrt-ci/gitlab/main.yml
 
 stages:
-  - build-deploy-container
   - pre-build
+  - build-deploy-container
   - build
   - test
   - deploy


### PR DESCRIPTION
This was changed without fully thinking on it and should obviously be
corrected.

Signed-off-by: Paul Spooren <mail@aparcar.org>