### PR TITLE
readd docker login on deploy

### DIFF
--- a/.gitlab/ci/base.yml
+++ b/.gitlab/ci/base.yml
@@ -23,3 +23,5 @@
     - master
   services:
     - docker:dind
+  before_script:
+    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"


### PR DESCRIPTION
This was removed during debugging and accidently forgotten to readd. It
fails to pass if no Docker credentials are given, which would be always
the case except on openwrtorg/master. In the future a test docker hub
account should be used instead of disabling it.

Signed-off-by: Paul Spooren <mail@aparcar.org>