### PR TITLE
No need for Python2 to build OpenWrt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -qq &&\
         git \
         libncurses5-dev \
         libssl-dev \
-        python2.7 \
         python3 \
         rsync \
         subversion \


### PR DESCRIPTION
Hello,
I just recently built all of OpenWrt with the SDK (x86_64and zynq targets) and then created respective images - all without Python2. I suggest you remove the request for python2.7 from your dockerfile.
Cheers,
Steffen