### PR TITLE
ci: fix imagebuilder test for x86/64

### DIFF
--- a/.gitlab/ci/imagebuilder.yml
+++ b/.gitlab/ci/imagebuilder.yml
@@ -22,4 +22,4 @@ test-imagebuilder:
   script:
     - cd /home/build/openwrt/
     - make image
-    - ls ./bin/targets/x86/64/*combined-squashfs.img.gz
+    - ls ./bin/targets/x86/64/*squashfs-combined.img.gz


### PR DESCRIPTION
That check is currently failing due to x86 image generation code
refactoring which changed naming of resulting images.

 ls: cannot access './bin/targets/x86/64/*combined-squashfs.img.gz': No such file or directory

Fixes #48
Signed-off-by: Petr Štetiar <ynezz@true.cz>