### PR TITLE
fixup imagebuilder test after x86 refactor

### DIFF
--- a/.gitlab/ci/imagebuilder.yml
+++ b/.gitlab/ci/imagebuilder.yml
@@ -22,4 +22,4 @@ test-imagebuilder:
   script:
     - cd /home/build/openwrt/
     - make image
-    - ls ./bin/targets/x86/64/*combined-squashfs.img.gz
+    - ls ./bin/targets/x86/64/*squashfs-combined.img.gz


### PR DESCRIPTION
The upstream commit cb007a7 introduced a different naming style for
created images, resulting in the imagebuilder test to fail.

Signed-off-by: Paul Spooren <mail@aparcar.org>