### PR TITLE
docker-build: Fix compatibility with older Docker versions

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -3,7 +3,10 @@
 set -ex
 
 DOCKERFILE="${DOCKERFILE:-Dockerfile}"
-docker build -t "$DOCKER_IMAGE:$TARGET-$BRANCH" -f "$DOCKERFILE" ./build
+# Copy Dockerfile inside build context to support older Docker versions
+# See https://github.com/docker/cli/pull/886
+cp "$DOCKERFILE" ./build/
+docker build -t "$DOCKER_IMAGE:$TARGET-$BRANCH" -f "./build/$DOCKERFILE" ./build
 
 if [ "$BRANCH" == "master" ]; then
     docker tag "$DOCKER_IMAGE:$TARGET-$BRANCH" "$DOCKER_IMAGE:$TARGET"


### PR DESCRIPTION
I'm using Docker version 17.05.0-ce (don't ask me why), and it works fine to build the images except for this small issue.