### PR TITLE
sdk: run syncs and sleeps between IO intense steps

### DIFF
--- a/.gitlab/ci/sdk.yml
+++ b/.gitlab/ci/sdk.yml
@@ -29,5 +29,9 @@ test-sdk:
     - make defconfig
     - ./scripts/feeds update base
     - ./scripts/feeds install busybox
+    - sync
+    - sleep 1
     - make package/busybox/compile V=s
+    - sync
+    - sleep 1
     - ls ./bin/packages/x86_64/base/busybox*


### PR DESCRIPTION
This tries to fix failing CIs when files are not found which should have
been there.

Signed-off-by: Paul Spooren <mail@aparcar.org>