### PR TITLE
allow defining of key folder variable

### DIFF
--- a/docker-common.sh
+++ b/docker-common.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-export GNUPGHOME="/keys/gpg/"
+export GNUPGHOME="${GNUPGHOME:-/keys/gpg/}"
 mkdir -p "$GNUPGHOME"
 chmod 700 "$GNUPGHOME"
 
-export USIGNHOME="/keys/usign/"
+export USIGNHOME="${USIGNHOME:-/keys/usign/}"
 mkdir -p "$USIGNHOME"
 chmod 700 "$USIGNHOME"
 

--- a/docker-download.sh
+++ b/docker-download.sh
@@ -3,8 +3,8 @@
 set -ex
 
 export FILE_HOST="${FILE_HOST:-downloads.openwrt.org}"
-export GNUPGHOME="/keys/gpg/"
-export USIGNHOME="/keys/usign/"
+export GNUPGHOME="${GNUPGHOME:-/keys/gpg/}"
+export USIGNHOME="${USIGNHOME:-/keys/usign/}"
 
 curl "https://$FILE_HOST/$DOWNLOAD_PATH/sha256sums" -fs -o sha256sums
 curl "https://$FILE_HOST/$DOWNLOAD_PATH/sha256sums.asc" -fs -o sha256sums.asc || true


### PR DESCRIPTION
This allows to overwrite GNUPGHOME and USIGNHOME for local testing.

Signed-off-by: Paul Spooren <mail@aparcar.org>