### PR TITLE
ci: fix imagebuilder test for 19.07 as well

### DIFF
--- a/.gitlab/ci/imagebuilder.yml
+++ b/.gitlab/ci/imagebuilder.yml
@@ -22,4 +22,4 @@ test-imagebuilder:
   script:
     - cd /home/build/openwrt/
     - make image
-    - ls ./bin/targets/x86/64/*squashfs-combined.img.gz
+    - ls ./bin/targets/x86/64/*.img.gz | grep squashfs


### PR DESCRIPTION
That check is currently failing due to different x86 image generation
code refactoring which changed naming of resulting images so they're now
different in master squashfs-combined Vs combined-squashfs in 19.07.

Signed-off-by: Petr Štetiar <ynezz@true.cz>