### PR TITLE
replace BRANCH with VERSION

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  BRANCH: master
+  VERSION: snapshot
 
 include:
   - local: .gitlab/ci/base.yml

--- a/.gitlab/ci/base.yml
+++ b/.gitlab/ci/base.yml
@@ -20,9 +20,8 @@
 generate-targets:
   stage: generate_targets
   script: |
-    git clone --depth 1 https://github.com/openwrt/openwrt.git
+    git clone --depth 1 --branch "$BRANCH" https://github.com/openwrt/openwrt.git
     cd openwrt/
-    git checkout "$BRANCH"
     bash ../generate_targets.sh
   artifacts:
     paths:

--- a/.gitlab/ci/imagebuilder.yml
+++ b/.gitlab/ci/imagebuilder.yml
@@ -5,11 +5,11 @@ build-imagebuilder_x86-64:
     DOCKER_IMAGE: "$CI_REGISTRY_IMAGE"
   script:
     - bash docker-imagebuilder.sh
-    - docker tag "$DOCKER_IMAGE:x86-64-$BRANCH" "$DOCKER_IMAGE:imagebuilder-$BRANCH-$CI_COMMIT_REF_SLUG"
-    - docker push "$DOCKER_IMAGE:imagebuilder-$BRANCH-$CI_COMMIT_REF_SLUG"
+    - docker tag "$DOCKER_IMAGE:x86-64-$VERSION" "$DOCKER_IMAGE:imagebuilder-$VERSION-$CI_COMMIT_REF_SLUG"
+    - docker push "$DOCKER_IMAGE:imagebuilder-$VERSION-$CI_COMMIT_REF_SLUG"
 
 test-imagebuilder:
-  image: "$CI_REGISTRY_IMAGE:imagebuilder-$BRANCH-$CI_COMMIT_REF_SLUG"
+  image: "$CI_REGISTRY_IMAGE:imagebuilder-$VERSION-$CI_COMMIT_REF_SLUG"
   stage: test
   script:
     - cd /home/build/openwrt/

--- a/.gitlab/ci/rootfs.yml
+++ b/.gitlab/ci/rootfs.yml
@@ -8,11 +8,11 @@ build-rootfs_x86-64:
     DOCKER_IMAGE: "$CI_REGISTRY_IMAGE"
   script:
     - bash docker-rootfs.sh
-    - docker tag "$DOCKER_IMAGE:x86-64-$BRANCH" "$DOCKER_IMAGE:rootfs-$BRANCH-$CI_COMMIT_REF_SLUG"
-    - docker push "$DOCKER_IMAGE:rootfs-$BRANCH-$CI_COMMIT_REF_SLUG"
+    - docker tag "$DOCKER_IMAGE:x86-64-$VERSION" "$DOCKER_IMAGE:rootfs-$VERSION-$CI_COMMIT_REF_SLUG"
+    - docker push "$DOCKER_IMAGE:rootfs-$VERSION-$CI_COMMIT_REF_SLUG"
 
 test-rootfs:
-  image: "$CI_REGISTRY_IMAGE:rootfs-$BRANCH-$CI_COMMIT_REF_SLUG"
+  image: "$CI_REGISTRY_IMAGE:rootfs-$VERSION-$CI_COMMIT_REF_SLUG"
   stage: test
   except:
     variables:

--- a/.gitlab/ci/sdk.yml
+++ b/.gitlab/ci/sdk.yml
@@ -6,11 +6,11 @@ build-sdk_x86-64:
     DOCKER_IMAGE: "$CI_REGISTRY_IMAGE"
   script:
     - bash docker-sdk.sh
-    - docker tag "$DOCKER_IMAGE:x86-64-$BRANCH" "$DOCKER_IMAGE:sdk-$BRANCH-$CI_COMMIT_REF_SLUG"
-    - docker push "$DOCKER_IMAGE:sdk-$BRANCH-$CI_COMMIT_REF_SLUG"
+    - docker tag "$DOCKER_IMAGE:x86-64-$VERSION" "$DOCKER_IMAGE:sdk-$VERSION-$CI_COMMIT_REF_SLUG"
+    - docker push "$DOCKER_IMAGE:sdk-$VERSION-$CI_COMMIT_REF_SLUG"
 
 test-sdk:
-  image: "$CI_REGISTRY_IMAGE:sdk-$BRANCH-$CI_COMMIT_REF_SLUG"
+  image: "$CI_REGISTRY_IMAGE:sdk-$VERSION-$CI_COMMIT_REF_SLUG"
   stage: test
   script:
     - cd ~/openwrt

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 This repository contains scripts to create Docker containers for OpenWrt. The
 scripts are run via an CI and upload such containers to docker.io.
 
-Used variables are `BRANCH`, `TARGET`, `DOCKER_USER`, `DOCKER_PASS` and `DOCKER_IMAGE`.
+Used variables are `VERSION`, `TARGET`, `DOCKER_USER`, `DOCKER_PASS` and `DOCKER_IMAGE`.
 
-`$BRANCH`: OpenWrt branch to build (e.g. "master")
+`$VERSION`: OpenWrt version to build (e.g. "snapshot" or "19.07.4")
 `$TARGET`: OpenWrt target to build (e.g. "x86-64")
 `$DOCKER_USER`: user to upload
 `$DOCKER_PASS`: passwort to upload

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -6,24 +6,31 @@ DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 # Copy Dockerfile inside build context to support older Docker versions
 # See https://github.com/docker/cli/pull/886
 cp "$DOCKERFILE" ./build/
-docker build -t "$DOCKER_IMAGE:$TARGET-$BRANCH" -f "./build/$DOCKERFILE" ./build
+docker build -t "$DOCKER_IMAGE:$TARGET-$VERSION" -f "./build/$DOCKERFILE" ./build
 
 if [ -n "$ARCH" ]; then
-    docker tag "$DOCKER_IMAGE:$TARGET-$BRANCH" "$DOCKER_IMAGE:$ARCH-$BRANCH"
+    docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:$ARCH-$VERSION"
 fi
 
-if [ "$BRANCH" == "master" ]; then
+if [ "$VERSION" == "snapshot" ]; then
+    # backwards compatibility. New setups should use snapshot instead
+    docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:$TARGET-master"
+
     if [ -n "$ARCH" ]; then
-        docker tag "$DOCKER_IMAGE:$TARGET-$BRANCH" "$DOCKER_IMAGE:$ARCH"
+        docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:$ARCH"
     fi
-    docker tag "$DOCKER_IMAGE:$TARGET-$BRANCH" "$DOCKER_IMAGE:$TARGET"
+    docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:$TARGET"
+
     if [ "$TARGET" == "x86-64" ]; then
-        docker tag "$DOCKER_IMAGE:$TARGET-$BRANCH" "$DOCKER_IMAGE:latest"
+        # backwards compatibility. New setups should use snapshot instead
+        docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:master"
+
+        docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:latest"
     fi
 fi
 
 if [ "$TARGET" == "x86-64" ]; then
-    docker tag "$DOCKER_IMAGE:$TARGET-$BRANCH" "$DOCKER_IMAGE:$BRANCH"
+    docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:$VERSION"
 fi
 
 rm -rf ./build

--- a/docker-imagebuilder.sh
+++ b/docker-imagebuilder.sh
@@ -4,14 +4,16 @@ set -ex
 
 TARGET=$(echo "$CI_JOB_NAME" | cut -d _ -f 2-)
 export TARGET="${TARGET:-x86-64}"
-export BRANCH="${BRANCH:-master}"
+export VERSION="${VERSION:-snapshot}"
 export DOCKER_IMAGE="${DOCKER_IMAGE:-openwrt-imagebuilder}"
 export DOWNLOAD_FILE="openwrt-imagebuilder*x86_64.tar.xz"
 
-if [ "$BRANCH" == "master" ]; then
+if [ "$VERSION" == "snapshot" ]; then
 	DOWNLOAD_PATH="snapshots/targets/$(echo "$TARGET" | tr '-' '/')"
+	export BRANCH="master"
 else
-	DOWNLOAD_PATH="releases/$BRANCH/targets/$(echo "$TARGET" | tr '-' '/')"
+	DOWNLOAD_PATH="releases/$VERSION/targets/$(echo "$TARGET" | tr '-' '/')"
+	export BRANCH="openwrt-$VERSION"
 fi
 export DOWNLOAD_PATH
 

--- a/docker-rootfs.sh
+++ b/docker-rootfs.sh
@@ -4,15 +4,17 @@ set -ex
 
 TARGET=$(echo "$CI_JOB_NAME" | cut -d _ -f 2-)
 export TARGET="${TARGET:-x86-64}"
-export BRANCH="${BRANCH:-master}"
+export VERSION="${VERSION:-snapshot}"
 export DOCKER_IMAGE="${DOCKER_IMAGE:-openwrt-rootfs}"
 export DOWNLOAD_FILE="openwrt-*-rootfs.tar.gz"
 export DOCKERFILE="Dockerfile.rootfs"
 
-if [ "$BRANCH" = "master" ]; then
+if [ "$VERSION" = "snapshot" ]; then
 	DOWNLOAD_PATH="snapshots/targets/$(echo "$TARGET" | tr '-' '/')"
+	export BRANCH="master"
 else
-	DOWNLOAD_PATH="releases/$BRANCH/targets/$(echo "$TARGET" | tr '-' '/')"
+	DOWNLOAD_PATH="releases/$VERSION/targets/$(echo "$TARGET" | tr '-' '/')"
+	export BRANCH="openwrt-$VERSION"
 fi
 export DOWNLOAD_PATH
 

--- a/docker-sdk.sh
+++ b/docker-sdk.sh
@@ -6,14 +6,16 @@ ARCH=$(echo "$CI_JOB_NAME" | cut -d _ -f 2-)
 # shellcheck disable=SC2153
 TARGET=$(echo "$TARGETS" | cut -d ' ' -f 1)
 export TARGET="${TARGET:-x86-64}"
-export BRANCH="${BRANCH:-master}"
+export VERSION="${VERSION:-snapshot}"
 export DOCKER_IMAGE="${DOCKER_IMAGE:-openwrt-sdk}"
 export DOWNLOAD_FILE="openwrt-sdk-*.Linux-x86_64.tar.xz"
 
-if [ "$BRANCH" == "master" ]; then
+if [ "$VERSION" == "snapshot" ]; then
 	DOWNLOAD_PATH="snapshots/targets/$(echo "$TARGET" | tr '-' '/')"
+	export BRANCH="master"
 else
-	DOWNLOAD_PATH="releases/$BRANCH/targets/$(echo "$TARGET" | tr '-' '/')"
+	DOWNLOAD_PATH="releases/$VERSION/targets/$(echo "$TARGET" | tr '-' '/')"
+	export BRANCH="openwrt-$VERSION"
 fi
 export DOWNLOAD_PATH
 
@@ -23,22 +25,28 @@ DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 # Copy Dockerfile inside build context to support older Docker versions
 # See https://github.com/docker/cli/pull/886
 cp "$DOCKERFILE" ./build/
-docker build -t "$DOCKER_IMAGE:$ARCH-$BRANCH" -f "./build/$DOCKERFILE" ./build
+docker build -t "$DOCKER_IMAGE:$ARCH-$VERSION" -f "./build/$DOCKERFILE" ./build
 
-if [ "$BRANCH" == "master" ]; then
-    docker tag "$DOCKER_IMAGE:$ARCH-$BRANCH" "$DOCKER_IMAGE:$ARCH"
+if [ "$VERSION" == "snapshot" ]; then
+    # backwards compatibility. New setups should use snapshot instead
+    docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:$TARGET-master"
+
+    docker tag "$DOCKER_IMAGE:$ARCH-$VERSION" "$DOCKER_IMAGE:$ARCH"
     if [ "$ARCH" == "x86_64" ]; then
-        docker tag "$DOCKER_IMAGE:$ARCH-$BRANCH" "$DOCKER_IMAGE:latest"
+        # backwards compatibility. New setups should use snapshot instead
+        docker tag "$DOCKER_IMAGE:$TARGET-$VERSION" "$DOCKER_IMAGE:master"
+
+        docker tag "$DOCKER_IMAGE:$ARCH-$VERSION" "$DOCKER_IMAGE:latest"
     fi
 fi
 
 if [ "$ARCH" == "x86_64" ]; then
-    docker tag "$DOCKER_IMAGE:$ARCH-$BRANCH" "$DOCKER_IMAGE:$BRANCH"
+    docker tag "$DOCKER_IMAGE:$ARCH-$VERSION" "$DOCKER_IMAGE:$VERSION"
 fi
 
 for TARGET_TAG in $TARGETS; do
     TARGET_TAG=$(echo "$TARGET_TAG" | tr '/' '-')
-    docker tag "$DOCKER_IMAGE:$ARCH-$BRANCH" "$DOCKER_IMAGE:$TARGET_TAG-$BRANCH"
+    docker tag "$DOCKER_IMAGE:$ARCH-$VERSION" "$DOCKER_IMAGE:$TARGET_TAG-$VERSION"
 done
 
 rm -rf ./build


### PR DESCRIPTION
The generate_targets.sh script requires to run on a specific branch to
only generate jobs for existing targets. The BRANCH variable was however
used for VERSION rather than the branch running on.

This changes the behaviour by automatically selecting the correct branch
and only taking the new VERSION env variable into account.

By doing so new Docker container tags include `snapshot` rather than
`master`, however for compatibility with existing setups the `master`
tag is still added.

Signed-off-by: Paul Spooren <mail@aparcar.org>