### PR TITLE
docker-sdk: print out SDK revision

### DIFF
--- a/docker-sdk.sh
+++ b/docker-sdk.sh
@@ -21,6 +21,8 @@ export DOWNLOAD_PATH
 
 ./docker-download.sh || exit 1
 
+echo "Using SDK from revision $(sed -ne 's/REVISION:=//p' ./build/include/version.mk)"
+
 DOCKERFILE="${DOCKERFILE:-Dockerfile}"
 # Copy Dockerfile inside build context to support older Docker versions
 # See https://github.com/docker/cli/pull/886


### PR DESCRIPTION
This should provide useful information in the CI logs for bisect
purposes etc. Otherwise its not possible to find out which version was
used, just the CI job timestamp.

Signed-off-by: Petr Štetiar <ynezz@true.cz>