### PR TITLE
chore: docker "latest" requires new flag

### DIFF
--- a/.gitlab/ci/deploy.yml
+++ b/.gitlab/ci/deploy.yml
@@ -18,7 +18,7 @@
     DOCKER_IMAGE: "openwrtorg/rootfs"
   script:
     - bash docker-rootfs.sh
-    - docker push "$DOCKER_IMAGE"
+    - docker push --all-tags "$DOCKER_IMAGE"
 
 .deploy-imagebuilder:
   extends: .deploy
@@ -26,7 +26,7 @@
     DOCKER_IMAGE: "openwrtorg/imagebuilder"
   script:
     - bash docker-imagebuilder.sh
-    - docker push "$DOCKER_IMAGE"
+    - docker push --all-tags "$DOCKER_IMAGE"
 
 .deploy-sdk:
   extends: .deploy
@@ -34,4 +34,4 @@
     DOCKER_IMAGE: "openwrtorg/sdk"
   script:
     - bash docker-sdk.sh
-    - docker push "$DOCKER_IMAGE"
+    - docker push --all-tags "$DOCKER_IMAGE"


### PR DESCRIPTION
Using the "latest" tag in `Dockerfile.deploy` recently updated to Docker
20.x which changed the default behaviour of `docker push`. It now
requires `--all-tags` to push all tags, unlike before in 19.x.

Signed-off-by: Paul Spooren <mail@aparcar.org>