### PR TITLE
Dockerfile: install gcc-multilib on host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -qq &&\
         curl \
         file \
         gawk \
+        gcc-multilib \
         gettext \
         git \
         libncurses5-dev \


### PR DESCRIPTION
This is required for luajit, which is in packages feed.
While it works fine for ARMv8 (tested by using Github Actions: aarch64_cortex-a53) and x84_x64 (tested inside Docker container, it does not work for 32-bits target and because of that we need to install gcc-multilib.

Luajit fails with the following output:
(tested against target: arm_cortex-a9+vfpv3-d16_musl_eabi inside Docker
SDK image)

```
/usr/include/limits.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory
 #include <bits/libc-header-start.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
And once gcc-multilib is installed, it works.
