### PR TITLE
Dockerfile: install vim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -qq &&\
         sudo \
         swig \
         unzip \
+        vim-tiny \
         wget \
         zlib1g-dev \
         && apt-get -y autoremove \


### PR DESCRIPTION
This can be useful as text editor might comes handy and it saves time.

For example, you need to do some changes in feeds.conf or even modify
some Makefiles inside Docker container, but there is no vim/nano.
You will need to update apt repository and then you can install things.
Let's have it preinstalled.