### PR TITLE
Dockerfile: install clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Paul Spooren <mail@aparcar.org>
 RUN apt-get update -qq &&\
     apt-get install -y \
         build-essential \
+        clang \
         curl \
         file \
         gawk \


### PR DESCRIPTION
Right now, XDP support for OpenWrt is on the rise. New packages and xdp loaders are written. However, the current github workflows will fail to crosscompile kernel xdp programms, since they do not support clang. Clang is the main tool to cross-compile xdp kernel scripts.

Clang only needs the correct endianess of the target system. This can just be added by checking in the Makefile

```
  ifeq ($(CONFIG_BIG_ENDIAN),y)
  BPF_TARGET=bpfeb
  else
  BPF_TARGET=bpfel
  endif
```

Missing clang support is one of the main reasons I currently not able to port xdp-tools to OpenWrt. With introduction of 5.10er kernel the XDP Support is also improved.