### PR TITLE
Dockerfile: install llvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq &&\
         git \
         libncurses5-dev \
         libssl-dev \
+        llvm \
         python2.7 \
         python3 \
         rsync \


### PR DESCRIPTION
We already added clang. It can compile a xdp programm to LLVM bytecode. However, we also need llvm that ships llc. llc is used to further compile the LLVM bytecode to assembly.