### PR TITLE
Dockerfile.xdp: add Dockerfile for xdp compiling

### DIFF
--- a/Dockerfile.xdp
+++ b/Dockerfile.xdp
@@ -1,0 +1,17 @@
+FROM openwrt/sdk
+
+MAINTAINER Nick Hainke <vincent@systemli.org>
+
+LABEL "com.github.actions.name"="OpenWrt SDK (XDP)"
+
+USER root
+
+RUN apt-get update -qq &&\
+    apt-get install -y \
+        clang \
+        llvm \
+        && apt-get -y autoremove \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
+
+USER build


### PR DESCRIPTION
Typically a xdp program program is compiled with:

    clang -O2 -target bpfeb -emit-llvm kern.c -o - | llc -march=bpfeb -filetype=obj -o kern.o

So we need clang and llvm.