### PR TITLE
install python3-distutils

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,6 +14,7 @@ RUN apt-get update -qq &&\
         libssl-dev \
         python2.7 \
         python3 \
+        python3-distutils \
         rsync \
         subversion \
         sudo \


### PR DESCRIPTION
The distutils module is a new hard requirement [0], so that packages can rely on
the host python3 interpreter having it available.

[0] https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=60af8d753343691c4a647bfc7c51ef6eb92df9f2
