### PR TITLE
docker: install g++-multilib

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -7,6 +7,7 @@ RUN apt-get update -qq &&\
         clang \
         curl \
         file \
+        g++-multilib \
         gawk \
         gcc-multilib \
         gettext \


### PR DESCRIPTION
Node fails to compile with:
```
  In file included from /usr/include/c++/8/memory:62,
  from ../deps/v8/src/libplatform/default-foreground-task-runner.h:8,
  from ../deps/v8/src/libplatform/default-foreground-task-runner.cc:5:
  /usr/include/c++/8/bits/stl_algobase.h:59:10: fatal error: bits/c++config.h:
    No such file or directory
  #include <bits/c++config.h>
          ^~~~~~~~~~~~~~~~~~
  compilation terminated.
```

Add g++-multilib to fix this.

Fixes: https://github.com/openwrt/packages/issues/17074

Signed-off-by: Nick Hainke <vincent@systemli.org>