### PR TITLE
Dockerfile.base: add aria2

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,6 +2,7 @@ FROM debian:11
 
 RUN apt-get update -qq &&\
     apt-get install -y \
+        aria2 \
         build-essential \
         ccache \
         clang \


### PR DESCRIPTION
OpenWrt now supports aria2c:
https://github.com/openwrt/openwrt/commit/d391236269314a759acb7dfb7ec01ccaa0e0b32c
