### PR TITLE
CI: add armsr, better debug output, actually skip skipped steps

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -99,12 +99,15 @@ jobs:
 
             JSON_IB="$JSON_IB"'{"target":"'"$TARGET"'"}'
 
-            if echo "$TARGET" | grep -E "x86/64|x86/generic|x86/geode|armvirt/32|armvirt/64|malta/be|mvebu/cortexa9"; then
-              [[ $FIRST_ROOTFS -ne 1 ]] && JSON_ROOTFS="$JSON_ROOTFS"','
-              FIRST_ROOTFS=0
+            case "$TARGET" in
+              x86/*|arm*|malta/be|mvebu/cortexa9)
+                [[ $FIRST_ROOTFS -ne 1 ]] && JSON_ROOTFS="$JSON_ROOTFS"','
+                FIRST_ROOTFS=0
 
-              JSON_ROOTFS="$JSON_ROOTFS"'{"target":"'"$TARGET"'","arch":"'"$ARCH"'"}'
-            fi
+                JSON_ROOTFS="$JSON_ROOTFS"'{"target":"'"$TARGET"'","arch":"'"$ARCH"'"}'
+              ;;
+            esac
+
           done <<< $(perl ./scripts/dump-target-info.pl targets 2>/dev/null | grep "$TARGET_FILTER")
 
           JSON_IB='{"include":'"$JSON_IB"']}'

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -359,9 +359,10 @@ jobs:
         run: docker run --platform=linux/${{ matrix.arch }} ${{ steps.build.outputs.imageid }} uname -m
 
       - name: Push
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v3
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: ${{ steps.build_args.outputs.args }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -112,13 +112,13 @@ jobs:
 
           JSON_IB='{"include":'"$JSON_IB"']}'
           echo -e "\n---- imagebuilders ----\n"
-          echo "$JSON_IB"
+          echo "$JSON_IB" | jq
           echo -e "\n---- imagebuilders ----\n"
           echo "imagebuilders=$JSON_IB" >> "$GITHUB_OUTPUT"
 
           JSON_ROOTFS='{"include":'"$JSON_ROOTFS"']}'
           echo -e "\n---- rootfs ----\n"
-          echo "$JSON_ROOTFS"
+          echo "$JSON_ROOTFS" | jq
           echo -e "\n---- rootfs ----\n"
           echo "rootfs=$JSON_ROOTFS" >> "$GITHUB_OUTPUT"
 
@@ -140,7 +140,7 @@ jobs:
 
           JSON='{"include":'"$JSON"']}'
           echo -e "\n---- sdks ----\n"
-          echo "$JSON"
+          echo "$JSON" | jq
           echo -e "\n---- sdks ----\n"
           echo "sdks=$JSON" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Instead of using a definied list with an if condition, use a case statement with wildcards to match on either `armsr` or `armvirt` (legacy). This should keep support for both 23.05.x and newer releases.