### PR TITLE
Branch updates

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,8 +15,9 @@ on:
 
   schedule:
     - cron: "0 5 * * *" # daily snapshot
-    - cron: "0 6 * * 0" # weekly 22.03-SNAPSHOT
-    - cron: "0 7 * * 0" # weekly 21.02-SNAPSHOT
+    - cron: "0 6 * * *" # daily 23.05-SNAPSHOT
+    - cron: "0 7 * * 0" # weekly 22.03-SNAPSHOT
+    - cron: "0 8 * * 0" # weekly 21.02-SNAPSHOT
 
 jobs:
   generate_matrix:
@@ -31,15 +32,22 @@ jobs:
       version_path: ${{ steps.find_targets.outputs.version_path }}
 
     steps:
+      - name: Set release to 23.05-SNAPSHOT
+        if: github.event.schedule == '0 6 * * *'
+        run: |
+          echo "VERSION=23.05-SNAPSHOT" >> "$GITHUB_ENV"
+          echo "VERSION_PATH=releases/23.05-SNAPSHOT" >> "$GITHUB_ENV"
+          echo "REF=openwrt-23.05" >> "$GITHUB_ENV"
+
       - name: Set release to 22.03-SNAPSHOT
-        if: github.event.schedule == '0 6 * * 0'
+        if: github.event.schedule == '0 7 * * 0'
         run: |
           echo "VERSION=22.03-SNAPSHOT" >> "$GITHUB_ENV"
           echo "VERSION_PATH=releases/22.03-SNAPSHOT" >> "$GITHUB_ENV"
           echo "REF=openwrt-22.03" >> "$GITHUB_ENV"
 
       - name: Set release to 21.02-SNAPSHOT
-        if: github.event.schedule == '0 7 * * 0'
+        if: github.event.schedule == '0 8 * * 0'
         run: |
           echo "VERSION=21.02-SNAPSHOT" >> "$GITHUB_ENV"
           echo "VERSION_PATH=releases/21.02-SNAPSHOT" >> "$GITHUB_ENV"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -158,6 +158,7 @@ jobs:
 
     steps:
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -337,6 +338,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     - cron: "0 5 * * *" # daily snapshot
     - cron: "0 6 * * *" # daily 23.05-SNAPSHOT
-    - cron: "0 7 * * 0" # weekly 22.03-SNAPSHOT
+    - cron: "0 7 * * 2" # weekly 22.03-SNAPSHOT
     - cron: "0 8 * * 0" # weekly 21.02-SNAPSHOT
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
           echo "REF=openwrt-23.05" >> "$GITHUB_ENV"
 
       - name: Set release to 22.03-SNAPSHOT
-        if: github.event.schedule == '0 7 * * 0'
+        if: github.event.schedule == '0 7 * * 2'
         run: |
           echo "VERSION=22.03-SNAPSHOT" >> "$GITHUB_ENV"
           echo "VERSION_PATH=releases/22.03-SNAPSHOT" >> "$GITHUB_ENV"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -192,6 +192,7 @@ jobs:
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.ref }}
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.version }}
             ${{ matrix.target }}-master,enable=${{ needs.generate_matrix.outputs.ref == 'main' }}
+            ${{ matrix.target }},enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' }}
             latest,enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' && matrix.target == 'x86/64'}}
 
       - name: Build and push
@@ -277,6 +278,19 @@ jobs:
             suffix=-master
           tags: ${{ matrix.tags }}
 
+      - name: Docker meta (target and arch)
+        if: needs.generate_matrix.outputs.version == 'SNAPSHOT'
+        id: meta_target_arch
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/openwrt/sdk
+            docker.io/openwrt/sdk
+            quay.io/openwrt/sdk
+          flavor: |
+            latest=false
+          tags: ${{ matrix.tags }}
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -285,6 +299,7 @@ jobs:
             ${{ steps.meta_ref.outputs.tags }}
             ${{ steps.meta_version.outputs.tags }}
             ${{ steps.meta_master.outputs.tags }}
+            ${{ steps.meta_target_arch.outputs.tags }}
           build-args: |
             DOWNLOAD_FILE=sdk-.*.Linux-x86_64.tar.xz
             VERSION_PATH=${{ needs.generate_matrix.outputs.version_path }}
@@ -344,9 +359,11 @@ jobs:
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.ref }}
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.version }}
             ${{ matrix.target }}-master,enable=${{ needs.generate_matrix.outputs.ref == 'main' }}
+            ${{ matrix.target }},enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' }}
             ${{ matrix.arch }}-${{ needs.generate_matrix.outputs.ref }}
             ${{ matrix.arch }}-${{ needs.generate_matrix.outputs.version }}
             ${{ matrix.arch }}-master,enable=${{ needs.generate_matrix.outputs.ref == 'main' }}
+            ${{ matrix.arch }},enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' }}
             latest,enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' && matrix.target == 'x86/64'}}
 
       - name: Generate build args

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Tag or branch to deploy (empty for master)"
-        default: "master"
+        description: "Tag or branch to deploy (empty for main)"
+        default: "main"
         required: false
       target:
         description: "Single target to build (empty for all)"
@@ -48,11 +48,11 @@ jobs:
       - name: Set relase manually
         if: github.event.inputs.ref != ''
         run: |
-          export REF=${{ github.event.inputs.ref }}
+          export REF=${{ github.event.inputs.ref == 'master' && 'main' || github.event.inputs.ref }}
           echo "REF=$REF" >> "$GITHUB_ENV"
 
           case $REF in
-            master)
+            main)
               VERSION=SNAPSHOT
               echo "VERSION_PATH=snapshots" >> "$GITHUB_ENV"
             ;;
@@ -144,7 +144,7 @@ jobs:
           echo -e "\n---- sdks ----\n"
           echo "sdks=$JSON" >> "$GITHUB_OUTPUT"
 
-          echo "ref=${REF:-master}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF:-main}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION:-SNAPSHOT}" >> "$GITHUB_OUTPUT"
           echo "version_path=${VERSION_PATH:-snapshots}" >> "$GITHUB_OUTPUT"
 
@@ -191,6 +191,7 @@ jobs:
           tags: |
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.ref }}
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.version }}
+            ${{ matrix.target }}-master,enable=${{ needs.generate_matrix.outputs.ref == 'main' }}
             latest,enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' && matrix.target == 'x86/64'}}
 
       - name: Build and push
@@ -262,6 +263,20 @@ jobs:
             suffix=-${{ needs.generate_matrix.outputs.version }}
           tags: ${{ matrix.tags }}
 
+      - name: Docker meta (master)
+        if: needs.generate_matrix.outputs.ref == 'main'
+        id: meta_master
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/openwrt/sdk
+            docker.io/openwrt/sdk
+            quay.io/openwrt/sdk
+          flavor: |
+            latest=false
+            suffix=-master
+          tags: ${{ matrix.tags }}
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -269,6 +284,7 @@ jobs:
           tags: |
             ${{ steps.meta_ref.outputs.tags }}
             ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_master.outputs.tags }}
           build-args: |
             DOWNLOAD_FILE=sdk-.*.Linux-x86_64.tar.xz
             VERSION_PATH=${{ needs.generate_matrix.outputs.version_path }}
@@ -327,8 +343,10 @@ jobs:
           tags: |
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.ref }}
             ${{ matrix.target }}-${{ needs.generate_matrix.outputs.version }}
+            ${{ matrix.target }}-master,enable=${{ needs.generate_matrix.outputs.ref == 'main' }}
             ${{ matrix.arch }}-${{ needs.generate_matrix.outputs.ref }}
             ${{ matrix.arch }}-${{ needs.generate_matrix.outputs.version }}
+            ${{ matrix.arch }}-master,enable=${{ needs.generate_matrix.outputs.ref == 'main' }}
             latest,enable=${{ needs.generate_matrix.outputs.version == 'SNAPSHOT' && matrix.target == 'x86/64'}}
 
       - name: Generate build args

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -31,21 +31,21 @@ jobs:
       version_path: ${{ steps.find_targets.outputs.version_path }}
 
     steps:
-      - name: Set relase to 22.03-SNAPSHOT
+      - name: Set release to 22.03-SNAPSHOT
         if: github.event.schedule == '0 6 * * 0'
         run: |
           echo "VERSION=22.03-SNAPSHOT" >> "$GITHUB_ENV"
           echo "VERSION_PATH=releases/22.03-SNAPSHOT" >> "$GITHUB_ENV"
           echo "REF=openwrt-22.03" >> "$GITHUB_ENV"
 
-      - name: Set relase to 21.02-SNAPSHOT
+      - name: Set release to 21.02-SNAPSHOT
         if: github.event.schedule == '0 7 * * 0'
         run: |
           echo "VERSION=21.02-SNAPSHOT" >> "$GITHUB_ENV"
           echo "VERSION_PATH=releases/21.02-SNAPSHOT" >> "$GITHUB_ENV"
           echo "REF=openwrt-21.02" >> "$GITHUB_ENV"
 
-      - name: Set relase manually
+      - name: Set release manually
         if: github.event.inputs.ref != ''
         run: |
           export REF=${{ github.event.inputs.ref == 'master' && 'main' || github.event.inputs.ref }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -17,7 +17,7 @@ on:
     - cron: "0 5 * * *" # daily snapshot
     - cron: "0 6 * * *" # daily 23.05-SNAPSHOT
     - cron: "0 7 * * 2" # weekly 22.03-SNAPSHOT
-    - cron: "0 8 * * 0" # weekly 21.02-SNAPSHOT
+    - cron: "0 8 16 * *" # monthly 21.02-SNAPSHOT
 
 jobs:
   generate_matrix:
@@ -47,7 +47,7 @@ jobs:
           echo "REF=openwrt-22.03" >> "$GITHUB_ENV"
 
       - name: Set release to 21.02-SNAPSHOT
-        if: github.event.schedule == '0 8 * * 0'
+        if: github.event.schedule == '0 8 16 * *'
         run: |
           echo "VERSION=21.02-SNAPSHOT" >> "$GITHUB_ENV"
           echo "VERSION_PATH=releases/21.02-SNAPSHOT" >> "$GITHUB_ENV"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -291,6 +291,17 @@ jobs:
             latest=false
           tags: ${{ matrix.tags }}
 
+      - name: Docker meta (latest)
+        if: needs.generate_matrix.outputs.version == 'SNAPSHOT' && matrix.target == 'x86/64'
+        id: meta_latest
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/openwrt/sdk
+            docker.io/openwrt/sdk
+            quay.io/openwrt/sdk
+          tags: latest
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -300,6 +311,7 @@ jobs:
             ${{ steps.meta_version.outputs.tags }}
             ${{ steps.meta_master.outputs.tags }}
             ${{ steps.meta_target_arch.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
           build-args: |
             DOWNLOAD_FILE=sdk-.*.Linux-x86_64.tar.xz
             VERSION_PATH=${{ needs.generate_matrix.outputs.version_path }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All currently available SDKs via tags in the following format:
 * `<target>-<subtarget>[-<branch|tag|version>]`
 
 The `branch|tag|version` can be something like `openwrt-22.03` (branch),
-`v22.03.4` (tag) or `21.02.3` (version). To use daily builds use either `master`
+`v22.03.4` (tag) or `21.02.3` (version). To use daily builds use either `main`
 or `SNAPSHOT`.
 
 ## `imagebuilder`
@@ -84,7 +84,7 @@ All currently available ImageBuilders via tags in the following format:
 * `<arch>[-<branch|tag|version>]`
 
 The `branch|tag|version` can be something like `openwrt-22.03` (branch),
-`v22.03.4` (tag) or `21.02.3` (version). To use daily builds use either `master`
+`v22.03.4` (tag) or `21.02.3` (version). To use daily builds use either `main`
 or `SNAPSHOT`.
 
 ## `rootfs` (experimental)


### PR DESCRIPTION
* Rename "master" to "main" (but continue to accept "master" for manual releases and add "master" suffixed tags)
* Add target/arch tags (no suffix) for snapshot images
* Add "latest" tag for x86_64 snapshot sdk
* Skip GitHub container registry login for imagebuilder/rootfs for pull requests
* Fix typos ("relase" to "release")
* Add daily builds for 23.05
* Change 22.03 builds to Tuesdays
* Change 21.02 builds from weekly to monthly

I don't know the exact buildbot schedules for 22.03 and 21.02 snapshots so the build scheduling here may have room for improvement.