### PR TITLE
don't fail on empty rootfs

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -331,6 +331,7 @@ jobs:
     name: RootFS
     runs-on: ubuntu-latest
     needs: generate_matrix
+    if: needs.generate_matrix.outputs.rootfs != '{"include":[]}'
     strategy:
       fail-fast: False
       matrix: ${{fromJson(needs.generate_matrix.outputs.rootfs)}}


### PR DESCRIPTION
Some targets don't create a rootfs. Don't fail in those cases.