### PR TITLE
update base image to buildworker 3.11.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE=ghcr.io/openwrt/buildbot/buildworker-v3.11.1:latest
+ARG BASE_IMAGE=ghcr.io/openwrt/buildbot/buildworker-v3.11.8:latest
 
-FROM ghcr.io/openwrt/buildbot/buildworker-v3.11.1:latest
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.11.8:latest
 
 WORKDIR /build/
 


### PR DESCRIPTION
Fixes https://github.com/openwrt/gh-action-sdk/issues/43

Disclaimer: This is just a reminder to update the base image and I didn't verify if everything is still working