### PR TITLE
Dockerfile: fix rootfs container generation

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -421,6 +421,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           load: true
+          file: Dockerfile.rootfs
           build-args: ${{ steps.build_args.outputs.args }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/${{ matrix.arch }}

--- a/Dockerfile.rootfs
+++ b/Dockerfile.rootfs
@@ -1,9 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v21
-
-FROM $BASE_IMAGE
-ARG USER=buildbot
-ARG WORKDIR=/builder/
-ARG CMD="/bin/bash"
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.11.8:v21 as builder
 
 ARG DOWNLOAD_FILE="imagebuilder-.*x86_64.tar.[xz|zst]"
 ARG TARGET=x86/64
@@ -15,15 +10,23 @@ ENV TARGET=$TARGET
 ENV FILE_HOST=$FILE_HOST
 ENV VERSION_PATH=$VERSION_PATH
 
-USER $USER
-WORKDIR $WORKDIR
+USER root
+WORKDIR /builder/rootfs
 
 ADD keys/*.asc /builder/keys/
 COPY --chmod=0755 setup.sh /builder/setup.sh
 
-ARG RUN_SETUP=0
-ENV RUN_SETUP=$RUN_SETUP
-RUN if [ "$RUN_SETUP" -eq 1 ]; then /builder/setup.sh; fi
+RUN /builder/setup.sh
+
+FROM scratch
+
+ARG CMD=/bin/ash
+ARG USER=root
+
+ENV CMD=$CMD
+ENV USER=$USER
+
+COPY --from=builder  /builder/rootfs/ /
 
 ENTRYPOINT [ ]
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,7 @@ DOWNLOAD_PATH="$VERSION_PATH/targets/$TARGET"
 wget "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums" -O sha256sums
 wget "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums.asc" -O sha256sums.asc
 
+cat /builder/keys/*.asc | gpg --import && rm -rf /builder/keys/
 gpg --with-fingerprint --verify sha256sums.asc sha256sums
 
 # determine archive name


### PR DESCRIPTION
Currently several rootfs containers are failing to build, as the buildbot user doesn't exists in those FROM:scratch containers:

```shell
  /usr/bin/docker buildx build (snip) --build-arg USER=root --build-arg BASE_IMAGE=scratch (snip)
  ...snip...
  #2 [1/5] ADD --chown=buildbot:buildbot keys/*.asc /builder/keys/
  #2 ERROR: invalid user index: -1
```

So lets fix it by avoiding need for ownership and simply import the keys
through pipe. Move the gpg key import into setup.sh script as well,
since this is the place where the keys are being used.

Also add a new Dockerfile.rootfs that must be used to generate a rootfs
container as the generic Dockerfile is not able to build the rootfs image.

Fixes: 9b55784b18f8 ("BREAKING: use setup.sh instead of Dockerfile")
References: https://github.com/openwrt/routing/pull/1107#issuecomment-2768156513
References: https://github.com/openwrt/docker/actions/runs/14165468179/job/39681375639#step:9:243