### PR TITLE
ci: fix rootfs container push

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -436,6 +436,7 @@ jobs:
           no-cache: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          file: Dockerfile.rootfs
           build-args: ${{ steps.build_args.outputs.args }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/${{ matrix.arch }}


### PR DESCRIPTION
Currently the Push stage fails for rootfs containers:

  ERROR: failed to solve: process "/bin/sh -c if [ \"$RUN_SETUP\" -eq 1 ]; then /builder/setup.sh; fi" did not complete successfully: unable to find user root: invalid argument

This is happening as the commit 9999f3c7e58 ("Dockerfile: fix rootfs container generation") changed the file argument on Build stage, but Push stage was omitted.

So lets fix it now by using working Dockerfile.rootfs.

References: https://github.com/openwrt/docker/actions/runs/14235351624/job/39893588545#step:11:288
Fixes: 79999f3c7e58 ("Dockerfile: fix rootfs container generation")
Fixes: 9b55784b18f8 ("BREAKING: use setup.sh instead of Dockerfile")