### PR TITLE
ci: fix rootfs container smoke test during push

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -344,7 +344,6 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        if: github.event_name == 'pull_request'
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static binfmt-support


### PR DESCRIPTION
Currently the Smoke test stage fails in the push event pipeline:

```shell
  Run docker run --platform=linux/mips_24kc sha256:d1700df716390394450d4851555b1904fd245c02e79573f6e97b4c24cdaafc8d uname -m
  exec /bin/uname: exec format error
  Error: Process completed with exit code 255.
```

This is not failing in the pull_request pipeline as the QEMU is properly configured. So lets fix the push event pipeline by configuring the QEMU in the same way, so the smoke test can pass.

Fixes: 3724e26fa114 ("ci: only use apt during testing")