### PR TITLE
ci: fix pushing of ImageBuilder containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -222,6 +222,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
+          push: true
           no-cache: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -370,10 +371,11 @@ jobs:
             '
 
       - name: Push
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
+          push: true
           no-cache: true
-          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.meta_ref.outputs.tags }}
             ${{ steps.meta_version.outputs.tags }}


### PR DESCRIPTION
Eric reported, that he is having problem with
imagebuilder:mediatek-filogic-master. The issue is caused by refactoring of Build Push stage in commit cda8065dc5d8 ("ci: add smoke testing of SDK and IB containers"), where I forget to enable pushing with `push: true` input as the default is `push: false`.

So lets fix it by explicitly enabling the push input, while at it unify the Push stage configs.

Fixes: #167
Fixes: cda8065dc5d8 ("ci: add smoke testing of SDK and IB containers")
Link: https://github.com/openwrt/docker/pull/168
Reported-by: Eric Fahlgren <ericfahlgren@gmail.com>