### PR TITLE
setup.sh: less verbose wget output

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,8 +7,8 @@ UPSTREAM_URL="${UPSTREAM_URL:-https://downloads.openwrt.org}"
 DOWNLOAD_FILE="${DOWNLOAD_FILE:-imagebuilder-.*x86_64.tar.[xz|zst]}"
 DOWNLOAD_PATH="$VERSION_PATH/targets/$TARGET"
 
-wget "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums" -O sha256sums
-wget "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums.asc" -O sha256sums.asc
+wget -nv "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums" -O sha256sums
+wget -nv "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums.asc" -O sha256sums.asc
 
 gpg --import /builder/keys/*.asc && rm -rf /builder/keys/
 gpg --with-fingerprint --verify sha256sums.asc sha256sums
@@ -17,7 +17,7 @@ gpg --with-fingerprint --verify sha256sums.asc sha256sums
 file_name="$(grep "$DOWNLOAD_FILE" sha256sums | cut -d "*" -f 2)"
 
 # download imagebuilder/sdk archive
-wget "$UPSTREAM_URL/$DOWNLOAD_PATH/$file_name"
+wget -nv "$UPSTREAM_URL/$DOWNLOAD_PATH/$file_name"
 
 # shrink checksum file to single desired file and verify downloaded archive
 grep "$file_name" sha256sums > sha256sums_min


### PR DESCRIPTION
This hides the download progress but is still more verbose then quiet.

This should help not to pollute the logs when downloading the sdk or imagebuilder with progress info.