### PR TITLE
ci: use mirror-03 as upstream provider

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,6 +1,9 @@
 name: Build and push containers
 run-name: ${{ inputs.ref }} ${{ inputs.target }}
 
+env:
+  UPSTREAM_URL: https://mirror-03.infra.openwrt.org
+
 on:
   # push:
   pull_request:


### PR DESCRIPTION
The job is triggered whenever a new target is uploaded. This happens the same moment the CDN cache is flushed, so it's possible that there is a flaky situation where the CDN is half way through purging the cache.

Let's use our own mirror for this.