### PR TITLE
ci: s/UPSTREAM_URL/FILE_HOST and use mirror-03 as upstream provider

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,6 +1,9 @@
 name: Build and push containers
 run-name: ${{ inputs.ref }} ${{ inputs.target }}
 
+env:
+  FILE_HOST: https://mirror-03.infra.openwrt.org
+
 on:
   # push:
   pull_request:

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,14 @@
-set -e
+set -ex
 
 # the inputs:
 TARGET="${TARGET:-x86/64}"
 VERSION_PATH="${VERSION_PATH:-snapshots}"
-UPSTREAM_URL="${UPSTREAM_URL:-https://downloads.openwrt.org}"
+FILE_HOST="${FILE_HOST:-https://downloads.openwrt.org}"
 DOWNLOAD_FILE="${DOWNLOAD_FILE:-imagebuilder-.*x86_64.tar.[xz|zst]}"
 DOWNLOAD_PATH="$VERSION_PATH/targets/$TARGET"
 
-wget -nv "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums" -O sha256sums
-wget -nv "$UPSTREAM_URL/$DOWNLOAD_PATH/sha256sums.asc" -O sha256sums.asc
+wget -nv "$FILE_HOST/$DOWNLOAD_PATH/sha256sums" -O sha256sums
+wget -nv "$FILE_HOST/$DOWNLOAD_PATH/sha256sums.asc" -O sha256sums.asc
 
 gpg --import /builder/keys/*.asc && rm -rf /builder/keys/
 gpg --with-fingerprint --verify sha256sums.asc sha256sums
@@ -17,7 +17,7 @@ gpg --with-fingerprint --verify sha256sums.asc sha256sums
 file_name="$(grep "$DOWNLOAD_FILE" sha256sums | cut -d "*" -f 2)"
 
 # download imagebuilder/sdk archive
-wget -nv "$UPSTREAM_URL/$DOWNLOAD_PATH/$file_name"
+wget -nv "$FILE_HOST/$DOWNLOAD_PATH/$file_name"
 
 # shrink checksum file to single desired file and verify downloaded archive
 grep "$file_name" sha256sums > sha256sums_min


### PR DESCRIPTION
The job is triggered whenever a new target is uploaded. This happens the same moment the CDN cache is flushed, so it's possible that there is a flaky situation where the CDN is half way through purging the cache.

Let's use our own mirror for this.