### PR TITLE
ci: hardcode rootfs DOWNLOAD_FILE to openwrt-x86-64-rootfs.tar.gz

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -471,7 +471,7 @@ jobs:
         id: build_args
         run: |
           echo 'args<<EOF
-            DOWNLOAD_FILE=openwrt-.*-rootfs.tar.gz
+            DOWNLOAD_FILE=openwrt-x86-64-rootfs.tar.gz
             WORKDIR=/
             USER=root
             VERSION_PATH=${{ needs.generate_matrix.outputs.version_path }}


### PR DESCRIPTION
In OpenWrt commit 246b216df57de45af20a1e66b337b41f63d11dda (main, backported to 25.12 as 78c88ce188b3266757391c34948dffd805e91f78 ), the targz "filesystem" now builds a `openwrt-x86-64-generic-targz-rootfs.tar.gz` binary with essential kmods alongside the simple `openwrt-x86-64-rootfs.tar.gz`, to provide a new way to install after manual partitioning instead of e.g. `dd`-ing from `-ext4-rootfs.img.gz`

However this do mean the current `DOWNLOAD_FILE=openwrt-.*-rootfs.tar.gz` regex line in `.github/workflows/containers.yml` line 474 would match two files and breaks `setup.sh` expecting a single file name; in which only the simple one without kmods is needed.

As all other `DOWNLOAD_FILE` in the CI file just assumes `x86_64`, it's natural the rootfs regex shall also hardcode `x86_64`, and as a further step hardcode the file name altogether.

```
> rg DOWNLOAD_FILE .github/
.github/workflows/containers.yml
216:            DOWNLOAD_FILE=imagebuilder-.*x86_64.tar.[xz|zst]
240:            DOWNLOAD_FILE=imagebuilder-.*x86_64.tar.[xz|zst]
362:            DOWNLOAD_FILE=sdk-.*.Linux-x86_64.tar.[xz|zst]
396:            DOWNLOAD_FILE=sdk-.*.Linux-x86_64.tar.[xz|zst]
474:            DOWNLOAD_FILE=openwrt-.*-rootfs.tar.gz
```

Fixes #202 