### PR TITLE
ci: use configuration variables for Docker Hub and Quay.io usernames

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,9 +3,9 @@ run-name: ${{ inputs.ref }} ${{ inputs.target }}
 
 env:
   FILE_HOST: https://mirror-03.infra.openwrt.org
-  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_USER: ${{ vars.DOCKER_USER }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-  QUAY_USER: ${{ secrets.QUAY_USER }}
+  QUAY_USER: ${{ vars.QUAY_USER }}
   QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
 on:
@@ -199,7 +199,7 @@ jobs:
         if: github.event_name != 'pull_request' && env.DOCKER_USER != '' && env.DOCKER_TOKEN != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Login to Quay.io Container Registry
@@ -207,7 +207,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
+          username: ${{ vars.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Docker meta
@@ -291,7 +291,7 @@ jobs:
         if: github.event_name != 'pull_request' && env.DOCKER_USER != '' && env.DOCKER_TOKEN != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Login to Quay.io Container Registry
@@ -299,7 +299,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
+          username: ${{ vars.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Docker meta (tag or branch)
@@ -458,7 +458,7 @@ jobs:
         if: github.event_name != 'pull_request' && env.DOCKER_USER != '' && env.DOCKER_TOKEN != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Login to Quay.io Container Registry
@@ -466,7 +466,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
+          username: ${{ vars.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Docker meta

--- a/README.md
+++ b/README.md
@@ -186,16 +186,16 @@ The GitHub Actions workflow `.github/workflows/containers.yml` automatically bui
 By default, the workflow will push containers to `ghcr.io/${{ github.repository_owner }}/<image>`. This works automatically out of the box using GitHub's built-in `GITHUB_TOKEN` and does not require any additional setup.
 
 ### Docker Hub & Quay.io
-To push to your own Docker Hub or Quay.io registries, you need to configure the following secrets under your repository's **Settings -> Secrets and variables -> Actions**:
+To push to your own Docker Hub or Quay.io registries, you need to configure the following variables and secrets under your repository's **Settings -> Secrets and variables -> Actions**:
 
 * **Docker Hub (docker.io)**:
-  * `DOCKER_USER` - Your Docker Hub username.
-  * `DOCKER_TOKEN` - Your Docker Hub Personal Access Token.
+  * `DOCKER_USER` (variable) - Your Docker Hub username.
+  * `DOCKER_TOKEN` (secret) - Your Docker Hub Personal Access Token.
 * **Quay.io (quay.io)**:
-  * `QUAY_USER` - Your Quay.io username.
-  * `QUAY_TOKEN` - Your Quay.io OAuth Token / Password.
+  * `QUAY_USER` (variable) - Your Quay.io username.
+  * `QUAY_TOKEN` (secret) - Your Quay.io OAuth Token / Password.
 
-If these secrets are not configured, the workflow will automatically skip logging in and pushing to these registries without failing the build.
+If these variables and secrets are not configured, the workflow will automatically skip logging in and pushing to these registries without failing the build.
 
 ## Build Your Own
 


### PR DESCRIPTION
I believe recent build failures (#211) are caused by GitHub redacting the Docker Hub and Quay.io usernames inside Docker tag names passed to buildx.

This changes the Docker Hub and Quay.io usernames to be stored as [configuration variables][1], which are not redacted by GitHub, rather than as secrets.

[1]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#defining-configuration-variables-for-multiple-workflows